### PR TITLE
Set default line ending setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "files.eol": "\n",
+    "ev3devBrowser.download.exclude": "{**/.*,LICENSE,README.md}"
+}


### PR DESCRIPTION
Create settings.json in .vscode.
Forces lineending to be preferable for the ev3brick https://sites.google.com/site/ev3python/troubleshoot